### PR TITLE
ci(docs): add dedicated GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,29 +49,4 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  docs:
-    runs-on: ubuntu-latest
-    needs: test
-    if: github.ref == 'refs/heads/main'
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      - name: Install MkDocs
-        run: |
-          pip install mkdocs mkdocs-material
-      - name: Build Docs
-        run: |
-          mkdocs build --strict
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
+  # Documentation deployment handled by docs.yaml workflow

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,56 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages-build
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install mkdocs mkdocs-material
+          # If a future extras group is added (e.g. .[docs]) replace above with: pip install .[docs]
+
+      - name: Build site
+        run: |
+          python -m mkdocs build --strict --site-dir site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+            path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Automated Threat Modeling & Attack Graph Generation for Kubernetes using LLM-ass
 
 [![CI](https://github.com/ThreatCompute/ThreatCompute/actions/workflows/ci.yaml/badge.svg)](https://github.com/ThreatCompute/ThreatCompute/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/ThreatCompute/ThreatCompute/branch/main/graph/badge.svg)](https://codecov.io/gh/ThreatCompute/ThreatCompute)
+[![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://threatcompute.github.io/ThreatCompute/)
 
 </div>
 


### PR DESCRIPTION
Adds docs.yaml workflow for building and deploying MkDocs site via GitHub Pages.

Changes:
- New docs.yaml workflow (build + upload + deploy jobs with concurrency and proper Pages permissions)
- Removed docs job from general CI pipeline to keep test workflow lean

Notes:
- Uses mkdocs + mkdocs-material directly; can switch to extras group once defined.
- Triggers on push to main and manual dispatch.

Next steps after merge:
- Optionally add a docs extra in setup (.[docs])
- Add mkdocstrings plugin for API docs.
- Consider caching pip deps for faster build.
