### PR TITLE
docs(build): normalize markdown_extensions for consistent local/CI builds

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ theme:
   favicon: images/logo.png
 markdown_extensions:
   - toc:
-    permalink: true
+      permalink: true
   - admonition
   - codehilite
   - tables
@@ -45,7 +45,7 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.critic
   - pymdownx.tasklist:
-    custom_checkbox: true
+      custom_checkbox: true
 extra:
   offline_mode_env: TC_OFFLINE
 plugins:


### PR DESCRIPTION
Normalize mkdocs configuration to resolve prior 'Invalid Markdown Extensions configuration' errors.

Changes:
- Corrected indentation for nested markdown extension options.
- Ensured tasklist and toc options parsed into mdx_configs.

Result:
- Local 'mkdocs build --strict' now succeeds.
- Provides stable baseline for further API docs automation (mkdocstrings) later.

No runtime code changes.

Follow-ups (not in this PR):
- Add advanced pages to nav (attack_graph_advanced, ttc_details, style_guide).
- Introduce docs extras group in packaging.
- Optional mkdocstrings integration for API reference.
