### PR TITLE
release: v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on Keep a Changelog (https://keepachangelog.com/en/1.0.0/) and this project adheres (from v0.1.0 onward) to Semantic Versioning (https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2025-09-05
+### Added
+- Initial public baseline with automated threat modeling, attack graph generation, and TTC computation pipeline.
+- Offline deterministic mode (`TC_OFFLINE`) enabling testable runs without external LLM calls.
+- Comprehensive pytest suite with coverage gating and multi-version CI matrix.
+- MkDocs documentation site (Material theme) with usage guides, advanced attack graph and TTC details, style guide, and contributing guidelines.
+- CODEOWNERS file establishing maintainer review flow.
+
+### Changed
+- Refactored threat model creation and technique analysis for lazy model loading & offline safety.
+- Improved attack graph generation (progress callbacks, early stop, defensive guards).
+- Simplified hierarchical TTC propagation logic.
+- Enhanced README with badges (CI, Docs) and offline mode explanation.
+- Updated LICENSE with multi-maintainer attribution and added COPYRIGHT file.
+
+### Fixed
+- CI ModuleNotFoundError resolved by exporting PYTHONPATH.
+- mkdocs.yml markdown_extensions configuration indentation issues causing build failures.
+- Attack path edge key mismatch (pluralization of 'techniques').
+
+### Security
+- Deterministic offline mode mitigates accidental external API/model calls during tests.
+
+### Tooling / CI
+- Split documentation deployment into dedicated `docs.yaml` GitHub Pages workflow.
+
+[0.1.0]: https://github.com/ThreatCompute/ThreatCompute/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Automated Threat Modeling & Attack Graph Generation for Kubernetes using LLM-ass
 [![CI](https://github.com/ThreatCompute/ThreatCompute/actions/workflows/ci.yaml/badge.svg)](https://github.com/ThreatCompute/ThreatCompute/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/gh/ThreatCompute/ThreatCompute/branch/main/graph/badge.svg)](https://codecov.io/gh/ThreatCompute/ThreatCompute)
 [![Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://threatcompute.github.io/ThreatCompute/)
+[![Release](https://img.shields.io/github/v/release/ThreatCompute/ThreatCompute?display_name=tag&sort=semver)](https://github.com/ThreatCompute/ThreatCompute/releases/latest)
 
 </div>
 


### PR DESCRIPTION
Release v0.1.0

Highlights:
- Initial baseline: automated threat modeling, attack graph generation, TTC computation.
- Offline deterministic mode (TC_OFFLINE) for reproducible CI/testing.
- Comprehensive pytest suite with coverage gating & multi-version CI.
- Material-themed documentation site with advanced guides (attack graph, TTC details, style guide) and offline mode doc.
- Added CODEOWNERS, COPYRIGHT, updated LICENSE attribution.
- Fixed mkdocs markdown_extensions configuration.
- Added release badge to README.

Changelog: see CHANGELOG.md (added in this branch).
Tag v0.1.0 already created & published.

Post-merge actions (optional):
- Add advanced pages to nav.
- Introduce docs extras group in packaging.
- Plan 0.2.0 (API docs via mkdocstrings, higher coverage threshold).
